### PR TITLE
郵便番号、バリデーション修正

### DIFF
--- a/app/models/purchase_records_address.rb
+++ b/app/models/purchase_records_address.rb
@@ -3,7 +3,7 @@ class PurchaseRecordsAddress
   attr_accessor :post_code, :prefecture_id, :city, :street_address, :building_name, :phone_number, :item_id, :user_id, :token
 
   with_options presence: true do
-    validates :post_code, format: { with: /\A\d{3}-?\d{4}\z/ }
+    validates :post_code, format: { with: /\A\d{3}-\d{4}\z/ }
     validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
     validates :city
     validates :street_address


### PR DESCRIPTION
# What
郵便番号のバリデーションを修正
# Why
「－」無しでは登録できないようにする為